### PR TITLE
Bugfix and Forum link update

### DIFF
--- a/ArtemisMissionEditor/Mission/Mission.cs
+++ b/ArtemisMissionEditor/Mission/Mission.cs
@@ -2657,25 +2657,31 @@ namespace ArtemisMissionEditor
                     if (type == "player")
                         AmountOfCreatePlayerStatements++;
 
-                    // Named object attributes.
-                    UpdateNamesLists_ScanExpression(statement, "x");
-                    UpdateNamesLists_ScanExpression(statement, "y");
-                    UpdateNamesLists_ScanExpression(statement, "z");
-                    UpdateNamesLists_ScanExpression(statement, "angle");
-
-                    // Unnamed object attributes.
-                    UpdateNamesLists_ScanExpression(statement, "startX");
-                    UpdateNamesLists_ScanExpression(statement, "startY");
-                    UpdateNamesLists_ScanExpression(statement, "startZ");
-                    UpdateNamesLists_ScanExpression(statement, "startAngle");
-                    UpdateNamesLists_ScanExpression(statement, "endX");
-                    UpdateNamesLists_ScanExpression(statement, "endY");
-                    UpdateNamesLists_ScanExpression(statement, "endZ");
-                    UpdateNamesLists_ScanExpression(statement, "endAngle");
-                    UpdateNamesLists_ScanExpression(statement, "count");
-                    UpdateNamesLists_ScanExpression(statement, "radius");
-                    UpdateNamesLists_ScanExpression(statement, "randomRange");
-                    UpdateNamesLists_ScanExpression(statement, "randomSeed");
+                    // Scan the expression for relevant attributes
+                    if (NamedObjectNames.ContainsKey(type))
+                    {
+                        // Named object attributes.
+                        UpdateNamesLists_ScanExpression(statement, "x");
+                        UpdateNamesLists_ScanExpression(statement, "y");
+                        UpdateNamesLists_ScanExpression(statement, "z");
+                        UpdateNamesLists_ScanExpression(statement, "angle");
+                    }
+                    else
+                    {
+                        // Unnamed object attributes.
+                        UpdateNamesLists_ScanExpression(statement, "startX");
+                        UpdateNamesLists_ScanExpression(statement, "startY");
+                        UpdateNamesLists_ScanExpression(statement, "startZ");
+                        UpdateNamesLists_ScanExpression(statement, "startAngle");
+                        UpdateNamesLists_ScanExpression(statement, "endX");
+                        UpdateNamesLists_ScanExpression(statement, "endY");
+                        UpdateNamesLists_ScanExpression(statement, "endZ");
+                        UpdateNamesLists_ScanExpression(statement, "endAngle");
+                        UpdateNamesLists_ScanExpression(statement, "count");
+                        UpdateNamesLists_ScanExpression(statement, "radius");
+                        UpdateNamesLists_ScanExpression(statement, "randomRange");
+                        UpdateNamesLists_ScanExpression(statement, "randomSeed");
+                    }
                 }
 
                 if (statement.Name == "set_monster_tag_data")

--- a/ArtemisMissionEditor/Properties/AssemblyInfo.cs
+++ b/ArtemisMissionEditor/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Artemis Mission Editor")]
-[assembly: AssemblyDescription("Complete mission editor suite for Artemis SBS\r\n\r\nGet the latest version on Artemis Wiki:\r\nhttp://artemiswiki.pbworks.com/w/page/53389687/Mission_Editor\r\n\r\nUpdated for Artemis 2.1.1 by Russ Judge\r\n\r\nUpdated for Artemis 2.3.0 by Fish\r\n\r\nBug fixes and tweaking by David Wolfe, Alice and Gomeric\r\n\r\nUpdated for Artemis 2.5.1 and later by Dave Thaler\r\n\r\nReport bugs on the forum thread at: http://www.artemis.eochu.com/?page_id=28#/20130130/artemis-mission-editor-2347979/")]
+[assembly: AssemblyDescription("Complete mission editor suite for Artemis SBS\r\n\r\nGet the latest version on Artemis Wiki:\r\nhttp://artemiswiki.pbworks.com/w/page/53389687/Mission_Editor\r\n\r\nUpdated for Artemis 2.1.1 by Russ Judge\r\n\r\nUpdated for Artemis 2.3.0 by Fish\r\n\r\nBug fixes and tweaking by David Wolfe, Alice and Gomeric\r\n\r\nUpdated for Artemis 2.5.1 and later by Dave Thaler\r\n\r\nReport bugs on the forum thread at: https://artemis.forumchitchat.com/post/artemis-mission-editor-8115862")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("ARME Corporation :-)")]
 [assembly: AssemblyProduct("Artemis Mission Editor")]

--- a/ArtemisMissionEditor/zzz_Changelog.txt
+++ b/ArtemisMissionEditor/zzz_Changelog.txt
@@ -1,3 +1,7 @@
+Version 2.7.3 (bugfix) [2018-March-20] (Scott Nalley)
+* Fixed bug where named objects positions weren't up to date on space map after saving / opening mission.
+* Updated the forum link in the description.
+----------------------
 Version 2.7.3 [2018-March-14] (Dave Thaler)
 * Added Drones ability to set_special
 * Added isTagged and tagOwnerSide object properties


### PR DESCRIPTION
Fixed bug where named objects positions weren't up to date on space map after saving / opening mission. and updated the forum link in the description.

The issue had to do with UpdateNamesLists_ScanExpression being called on a named object statements with "x" and also "startX" (along with other dimensions) and was causing an issues, I assume to it being case insensitive and finding "x" within the "startX" string. So now it only calls it on relevant attributes if it's named or not, so it does either "x" OR "startX".

Included changes in the change log but didn't change the version, so it could potentially be included in the next version that's officially released.